### PR TITLE
ORD-539 -- Add String.startsWith polyfill to fix CCP not loading in IE

### DIFF
--- a/packages/react-scripts/config/polyfills.js
+++ b/packages/react-scripts/config/polyfills.js
@@ -24,3 +24,11 @@ require('whatwg-fetch');
 // Object.assign() is commonly used with React.
 // It will use the native implementation if it's present and isn't buggy.
 Object.assign = require('object-assign');
+
+// String.prototype.startsWith polyfill (ORD-539 re: CCP not starting on IE)
+if (!String.prototype.startsWith) {
+  String.prototype.startsWith = function(searchString, position){
+    position = position || 0;
+    return this.substr(position, searchString.length) === searchString;
+  };
+}


### PR DESCRIPTION
IE wasn't loading the app due to not knowing String.startsWith.  Though this code doesn't actually exist in our app, babel transpiles a few lines to use it.

Tested by running `npm run eject`, modifying the `scripts/packages/react-scripts/configs/polyfill.js`, running `npm run build`, serving the dist folder locally, and testing in IE 
11.  

Note --  this gets past the 'startsWith' error in IE10, but blows up on using es6 Map in IE10

https://clearcapital.atlassian.net/browse/ORD-539

