### PR TITLE
add string.includes for IE support

### DIFF
--- a/packages/react-scripts/config/polyfills.js
+++ b/packages/react-scripts/config/polyfills.js
@@ -32,3 +32,19 @@ if (!String.prototype.startsWith) {
     return this.substr(position, searchString.length) === searchString;
   };
 }
+
+// String.prototype.includes polyfill for IE (related to ORD-539)
+if (!String.prototype.includes) {
+  String.prototype.includes = function(search, start) {
+    'use strict';
+    if (typeof start !== 'number') {
+      start = 0;
+    }
+
+    if (start + search.length > this.length) {
+      return false;
+    } else {
+      return this.indexOf(search, start) !== -1;
+    }
+  };
+}


### PR DESCRIPTION
IE doesn't natively support String.includes, added polyfill to `packages/react-scripts/config/polyfill.js`
