### PR TITLE
Add Array.find and Array.includes polyfill -- READ NOTE FOR TODO

### DIFF
--- a/packages/react-scripts/config/polyfills.js
+++ b/packages/react-scripts/config/polyfills.js
@@ -25,6 +25,8 @@ require('whatwg-fetch');
 // It will use the native implementation if it's present and isn't buggy.
 Object.assign = require('object-assign');
 
+// TODO decide if it would be better to import a library like core-js and require these polyfills from those modules,
+// TODO-cont or just keep these methods defined here
 // String.prototype.startsWith polyfill (ORD-539 re: CCP not starting on IE)
 if (!String.prototype.startsWith) {
   String.prototype.startsWith = function(searchString, position){
@@ -33,7 +35,7 @@ if (!String.prototype.startsWith) {
   };
 }
 
-// String.prototype.includes polyfill for IE (related to ORD-539)
+// String.prototype.includes polyfill for IE (ORD-539 re: CCP not starting on IE)
 if (!String.prototype.includes) {
   String.prototype.includes = function(search, start) {
     'use strict';
@@ -47,4 +49,103 @@ if (!String.prototype.includes) {
       return this.indexOf(search, start) !== -1;
     }
   };
+}
+
+// Array.prototype.find polyfill for IE (ORD-539 re: CCP not starting on IE)
+// https://tc39.github.io/ecma262/#sec-array.prototype.find
+if (!Array.prototype.find) {
+  Object.defineProperty(Array.prototype, 'find', {
+    value: function(predicate) {
+      // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      var thisArg = arguments[1];
+
+      // 5. Let k be 0.
+      var k = 0;
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return kValue.
+        var kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return kValue;
+        }
+        // e. Increase k by 1.
+        k++;
+      }
+
+      // 7. Return undefined.
+      return undefined;
+    }
+  });
+}
+
+// Array.prototype.includes polyfill for IE (ORD-539 re: CCP not starting on IE)
+// https://tc39.github.io/ecma262/#sec-array.prototype.includes
+if (!Array.prototype.includes) {
+  Object.defineProperty(Array.prototype, 'includes', {
+    value: function(searchElement, fromIndex) {
+
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      // 1. Let O be ? ToObject(this value).
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If len is 0, return false.
+      if (len === 0) {
+        return false;
+      }
+
+      // 4. Let n be ? ToInteger(fromIndex).
+      //    (If fromIndex is undefined, this step produces the value 0.)
+      var n = fromIndex | 0;
+
+      // 5. If n ≥ 0, then
+      //  a. Let k be n.
+      // 6. Else n < 0,
+      //  a. Let k be len + n.
+      //  b. If k < 0, let k be 0.
+      var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+      function sameValueZero(x, y) {
+        return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
+      }
+
+      // 7. Repeat, while k < len
+      while (k < len) {
+        // a. Let elementK be the result of ? Get(O, ! ToString(k)).
+        // b. If SameValueZero(searchElement, elementK) is true, return true.
+        if (sameValueZero(o[k], searchElement)) {
+          return true;
+        }
+        // c. Increase k by 1.
+        k++;
+      }
+
+      // 8. Return false
+      return false;
+    }
+  });
 }


### PR DESCRIPTION
Added Array.find and Array.includes methods for polyfill.  

TODO -- [core-js](https://www.npmjs.com/package/core-js) is a good library for polyfilling, but I don't know if it would be beneficial to pull that in then add require (core-js/XXpolyfill) rather than having these methods written plain.  thoughts @jordanpapaleo @jonlu @graywithanA @ericmmartin?
